### PR TITLE
Safe mode build: convert modules to ES5, no SystemJS dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "serveit": "browser-sync start --files 'src/**/*.html,src/**/*.css,src/**/*.js' --server 'src'",
     "buildMode": "jspm bundle startup + dropdown/dropdown --inject",
+    "buildSafeMode": "jspm bundle-sfx startup + dropdown/dropdown safe-bundle.js",
     "devMode": "jspm unbundle"
   },
   "devDependencies": {


### PR DESCRIPTION
Self executed bundle file, without dependencies and just ES5.
