### PR TITLE
Properly escaping string for browser-sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dropdown",
   "version": "1.0.0",
   "scripts": {
-    "serveit": "browser-sync start --files 'src/**/*.html,src/**/*.css,src/**/*.js' --server 'src'",
+    "serveit": "browser-sync start --files \"src/**/*.html,src/**/*.css,src/**/*.js\" --server src",
     "buildMode": "jspm bundle startup + dropdown/dropdown --inject",
     "buildSafeMode": "jspm bundle-sfx startup + dropdown/dropdown safe-bundle.js",
     "devMode": "jspm unbundle"


### PR DESCRIPTION
Found this repo through your article [Choose ES6 modules Today!](http://developer.telerik.com/featured/choose-es6-modules-today/) and spent way too long trying to figure out why browser-sync wasn't working.

Please consider pulling and/or updating article to save some other noob's time, thanks!
